### PR TITLE
ice40: correct device size comments

### DIFF
--- a/ice40/devices/layouts/N1k/ntemplate.N1k.fixed_layout.xml
+++ b/ice40/devices/layouts/N1k/ntemplate.N1k.fixed_layout.xml
@@ -6,7 +6,7 @@
  -->
  <col     type="EMPTY"          startx="0"  priority="30"/>
  <col     type="BLK_TL-PIO_A"   startx="1"  priority="10"/>
- <region  type="BLK_TL-PLB"     startx="2" endx="13" starty="2" endy="17" priority="4"/> <!-- Logic blocks 11x15 -->
+ <region  type="BLK_TL-PLB"     startx="2" endx="13" starty="2" endy="17" priority="4"/> <!-- Logic blocks 12x16 -->
  <col     type="BLK_TL-PIO_A"   startx="14" priority="10"/>
  <col     type="EMPTY"          startx="15" priority="30"/>
 

--- a/ice40/devices/layouts/N384/ntemplate.N384.fixed_layout.xml
+++ b/ice40/devices/layouts/N384/ntemplate.N384.fixed_layout.xml
@@ -2,7 +2,7 @@
 <fixed_layout name="{N}384" width="12" height="12">
  <col    type="EMPTY"            startx="0"  priority="30"/>
  <col    type="BLK_TL-PIO_L"     startx="1"  priority="10"/>
- <region type="BLK_TL-PLB"       startx="2" endx="7" starty="2" endy="9" priority="4"/> <!-- Logic blocks 8x10 -->
+ <region type="BLK_TL-PLB"       startx="2" endx="7" starty="2" endy="9" priority="4"/> <!-- Logic blocks 6x8 -->
  <col    type="BLK_TL-PIO_R"     startx="8"  priority="10"/>
  <col    type="EMPTY"            startx="9"  priority="30"/>
  <col    type="EMPTY"            startx="10" priority="30"/>

--- a/ice40/devices/layouts/N8k/ntemplate.N8k.fixed_layout.xml
+++ b/ice40/devices/layouts/N8k/ntemplate.N8k.fixed_layout.xml
@@ -6,7 +6,7 @@
  -->
  <col     type="EMPTY"          startx="0"  priority="30"/>
  <col     type="BLK_TL-PIO_L"   startx="1"  priority="10"/>
- <region  type="BLK_TL-PLB"     startx="2" endx="33" starty="2" endy="33" priority="4"/> <!-- Logic blocks 31x31 -->
+ <region  type="BLK_TL-PLB"     startx="2" endx="33" starty="2" endy="33" priority="4"/> <!-- Logic blocks 32x32 -->
  <col     type="BLK_TL-PIO_R"   startx="34" priority="10"/>
  <col     type="EMPTY"          startx="35" priority="30"/>
 


### PR DESCRIPTION
For SymbiFlow#105

Several comments appear to be wrong. I've updated the comments using a combination of the following two resources:
-http://www.clifford.at/icestorm/
-http://hedmen.org/icestorm-doc/icestorm.html

With the former being the primary source, and the latter for 384, which doesn't appear graphically in the above icestorm documentation. Note that some of the logic areas contain BRAMs, but this does not effect the overall area that logic tiles occupy.